### PR TITLE
Parse grammars with `proc_macro` tokens and remove "negative lookahead".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ rust:
   - beta
   - nightly
 cache: cargo
-script: cargo test --all
+before_script: rustup component add rustfmt
+script:
+  - cargo fmt --all -- --check
+  - cargo test --all
+
 branches:
   only:
   - master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,12 +64,10 @@ impl<Pat> Grammar<Pat> {
                     // FIXME(cad97) this will insert too many whitespace rules
                     // A* %% B => ???
                     // Currently, A* %% (WS B WS), which allows trailing whitespace incorrectly
-                    Some((sep, SepKind::Trailing)) => {
-                        elem.fold(self).repeat_more(Some((
-                            self.whitespace.clone() + sep.clone() + self.whitespace.clone(),
-                            SepKind::Trailing,
-                        )))
-                    }
+                    Some((sep, SepKind::Trailing)) => elem.fold(self).repeat_more(Some((
+                        self.whitespace.clone() + sep.clone() + self.whitespace.clone(),
+                        SepKind::Trailing,
+                    ))),
                 }
             }
             fn fold_repeat_more(


### PR DESCRIPTION
Counterpart to https://github.com/rust-lang/gll/pull/113.