### PR TITLE
Remove 'static requirements from patterns and improve their printing.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -160,20 +160,29 @@ impl<'a> Input for &'a str {
     }
 }
 
-pub trait InputMatch<Pat> {
-    fn match_left(&self, pat: &'static Pat) -> Option<usize>;
-    fn match_right(&self, pat: &'static Pat) -> Option<usize>;
+pub trait InputMatch<Pat: ?Sized> {
+    fn match_left(&self, pat: &Pat) -> Option<usize>;
+    fn match_right(&self, pat: &Pat) -> Option<usize>;
 }
 
-impl<T: PartialEq> InputMatch<&'static [T]> for [T] {
-    fn match_left(&self, pat: &&[T]) -> Option<usize> {
+impl<I: ?Sized + InputMatch<Pat>, Pat: ?Sized> InputMatch<&'_ Pat> for I {
+    fn match_left(&self, &pat: &&Pat) -> Option<usize> {
+        self.match_left(pat)
+    }
+    fn match_right(&self, &pat: &&Pat) -> Option<usize> {
+        self.match_right(pat)
+    }
+}
+
+impl<T: PartialEq> InputMatch<[T]> for [T] {
+    fn match_left(&self, pat: &[T]) -> Option<usize> {
         if self.starts_with(pat) {
             Some(pat.len())
         } else {
             None
         }
     }
-    fn match_right(&self, pat: &&[T]) -> Option<usize> {
+    fn match_right(&self, pat: &[T]) -> Option<usize> {
         if self.ends_with(pat) {
             Some(pat.len())
         } else {
@@ -201,15 +210,15 @@ impl<T: PartialOrd> InputMatch<RangeInclusive<T>> for [T] {
     }
 }
 
-impl InputMatch<&'static str> for str {
-    fn match_left(&self, pat: &&str) -> Option<usize> {
+impl InputMatch<str> for str {
+    fn match_left(&self, pat: &str) -> Option<usize> {
         if self.starts_with(pat) {
             Some(pat.len())
         } else {
             None
         }
     }
-    fn match_right(&self, pat: &&str) -> Option<usize> {
+    fn match_right(&self, pat: &str) -> Option<usize> {
         if self.ends_with(pat) {
             Some(pat.len())
         } else {

--- a/src/proc_macro_input.rs
+++ b/src/proc_macro_input.rs
@@ -52,8 +52,8 @@ impl Input for TokenStream {
     }
 }
 
-impl InputMatch<&'static [FlatTokenPat<&'static str>]> for [FlatToken] {
-    fn match_left(&self, &pat: &&[FlatTokenPat<&str>]) -> Option<usize> {
+impl InputMatch<[FlatTokenPat<&'_ str>]> for [FlatToken] {
+    fn match_left(&self, pat: &[FlatTokenPat<&str>]) -> Option<usize> {
         if self
             .iter()
             .zip(pat)
@@ -66,7 +66,7 @@ impl InputMatch<&'static [FlatTokenPat<&'static str>]> for [FlatToken] {
             None
         }
     }
-    fn match_right(&self, &pat: &&[FlatTokenPat<&str>]) -> Option<usize> {
+    fn match_right(&self, pat: &[FlatTokenPat<&str>]) -> Option<usize> {
         if self
             .iter()
             .zip(pat)

--- a/src/scannerless.rs
+++ b/src/scannerless.rs
@@ -1,13 +1,33 @@
 use crate::rule::{MatchesEmpty, MaybeKnown};
 use std::char;
+use std::fmt;
 use std::ops::{self, Bound, RangeBounds};
 
 pub type Context<S = String> = crate::context::Context<Pat<S>>;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Pat<S = String, C = char> {
     String(S),
     Range(C, C),
+}
+
+impl<S: fmt::Debug> fmt::Debug for Pat<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Pat::String(s) => s.fmt(f),
+            &Pat::Range(start, end) => {
+                if start != '\0' {
+                    start.fmt(f)?;
+                }
+                f.write_str("..")?;
+                if end != char::MAX {
+                    f.write_str("=")?;
+                    end.fmt(f)?;
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<'a, C> From<&'a str> for Pat<&'a str, C> {


### PR DESCRIPTION
Now they should look identical to syntax that can be used to create them.