### PR TITLE
rule: intern fields and store them in a tree matching the rule structure.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::rule::Rule;
+use crate::rule::{Fields, Rule};
 use elsa::FrozenVec;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -93,6 +93,7 @@ macro_rules! interners {
 interners! {
     IStr => str,
     IRule => Rule<Pat>,
+    IFields => Fields,
 }
 
 impl<Pat> InternInCx<Pat> for &'_ str {
@@ -115,5 +116,20 @@ impl<Pat: Eq + Hash> InternInCx<Pat> for Rule<Pat> {
 
     fn intern_in_cx(self, cx: &Context<Pat>) -> Self::Interned {
         IRule(cx.interners.IRule.intern(self))
+    }
+}
+
+// FIXME(eddyb) automate this away somehow.
+impl AsRef<Self> for Fields {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<Pat> InternInCx<Pat> for Fields {
+    type Interned = IFields;
+
+    fn intern_in_cx(self, cx: &Context<Pat>) -> Self::Interned {
+        IFields(cx.interners.IFields.intern(self))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 pub struct Grammar {
-    pub rules: IndexMap<IStr, rule::RuleWithNamedFields>,
+    pub rules: IndexMap<IStr, rule::RuleWithFields>,
 }
 
 impl Grammar {
@@ -44,7 +44,7 @@ impl Grammar {
             rules: IndexMap::new(),
         }
     }
-    pub fn define(&mut self, name: IStr, rule: rule::RuleWithNamedFields) {
+    pub fn define(&mut self, name: IStr, rule: rule::RuleWithFields) {
         self.rules.insert(name, rule);
     }
     pub fn extend(&mut self, other: Self) {
@@ -53,7 +53,7 @@ impl Grammar {
     pub fn insert_whitespace<Pat: Eq + Hash>(
         self,
         cx: &Context<Pat>,
-        whitespace: rule::RuleWithNamedFields,
+        whitespace: rule::RuleWithFields,
     ) -> Self {
         Grammar {
             rules: self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl Grammar {
             rules: self
                 .rules
                 .into_iter()
-                .map(|(name, rule)| (name, rule.insert_whitespace(cx, whitespace.clone())))
+                .map(|(name, rule)| (name, rule.insert_whitespace(cx, whitespace)))
                 .collect(),
         }
     }

--- a/src/proc_macro.rs
+++ b/src/proc_macro.rs
@@ -13,7 +13,7 @@ pub fn builtin(cx: &Context) -> crate::Grammar {
     let mut g = crate::Grammar::new();
 
     let ident = eat(Pat(vec![FlatTokenPat::Ident(None)])).finish(cx);
-    g.define(cx.intern("IDENT"), ident.clone());
+    g.define(cx.intern("IDENT"), ident);
 
     g.define(
         cx.intern("LIFETIME"),
@@ -32,10 +32,10 @@ pub fn builtin(cx: &Context) -> crate::Grammar {
         joint: None,
     }]))
     .finish(cx);
-    g.define(cx.intern("PUNCT"), punct.clone());
+    g.define(cx.intern("PUNCT"), punct);
 
     let literal = eat(Pat(vec![FlatTokenPat::Literal])).finish(cx);
-    g.define(cx.intern("LITERAL"), literal.clone());
+    g.define(cx.intern("LITERAL"), literal);
 
     let delim = |c| eat(FlatTokenPat::Delim(c));
     let group = |open, close| delim(open) + call("TOKEN_TREE").repeat_many() + delim(close);

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -694,7 +694,7 @@ impl RuleWithNamedFields {
                 left: RuleWithNamedFields,
                 right: RuleWithNamedFields,
             ) -> RuleWithNamedFields {
-                (left.fold(self) + self.whitespace.clone() + right.fold(self)).finish(self.cx())
+                (left.fold(self) + self.whitespace + right.fold(self)).finish(self.cx())
             }
             fn fold_repeat_many(
                 &mut self,
@@ -706,23 +706,17 @@ impl RuleWithNamedFields {
                 match sep {
                     // A* => A* % WS
                     None => elem
-                        .repeat_more_sep(self.whitespace.clone(), SepKind::Simple)
+                        .repeat_more_sep(self.whitespace, SepKind::Simple)
                         .finish(self.cx),
                     // A* % B => A* % (WS B WS)
                     Some((sep, SepKind::Simple)) => elem
-                        .repeat_more_sep(
-                            self.whitespace.clone() + sep + self.whitespace.clone(),
-                            SepKind::Simple,
-                        )
+                        .repeat_more_sep(self.whitespace + sep + self.whitespace, SepKind::Simple)
                         .finish(self.cx),
                     // FIXME(cad97) this will insert too many whitespace rules
                     // A* %% B => ???
                     // Currently, A* %% (WS B WS), which allows trailing whitespace incorrectly
                     Some((sep, SepKind::Trailing)) => elem
-                        .repeat_more_sep(
-                            self.whitespace.clone() + sep + self.whitespace.clone(),
-                            SepKind::Trailing,
-                        )
+                        .repeat_more_sep(self.whitespace + sep + self.whitespace, SepKind::Trailing)
                         .finish(self.cx),
                 }
             }
@@ -736,21 +730,17 @@ impl RuleWithNamedFields {
                 match sep {
                     // A+ => A+ % WS
                     None => elem
-                        .repeat_more_sep(self.whitespace.clone(), SepKind::Simple)
+                        .repeat_more_sep(self.whitespace, SepKind::Simple)
                         .finish(self.cx),
                     // A+ % B => A+ % (WS B WS)
                     Some((sep, SepKind::Simple)) => elem
                         .fold(self)
-                        .repeat_more_sep(
-                            self.whitespace.clone() + sep + self.whitespace.clone(),
-                            SepKind::Simple,
-                        )
+                        .repeat_more_sep(self.whitespace + sep + self.whitespace, SepKind::Simple)
                         .finish(self.cx),
                     // A+ %% B => A+ % (WS B WS) (WS B)?
-                    Some((sep, SepKind::Trailing)) => (elem.repeat_more_sep(
-                        self.whitespace.clone() + sep.clone() + self.whitespace.clone(),
-                        SepKind::Simple,
-                    ) + (self.whitespace.clone() + sep).opt())
+                    Some((sep, SepKind::Trailing)) => (elem
+                        .repeat_more_sep(self.whitespace + sep + self.whitespace, SepKind::Simple)
+                        + (self.whitespace + sep).opt())
                     .finish(self.cx),
                 }
             }


### PR DESCRIPTION
While exploring a better API for #10 I realized the path trick, as useful as it is otherwise, was holding me back, because it makes recursing on a rule/parse forest, while keeping track of fields, expensive.
You can already see an improvement in the `Folder` API, for example.

I'll update #10 to use this next, possibly a good idea to wait for that before merging.